### PR TITLE
fix regex escape in tests

### DIFF
--- a/src/api/phoneNumbers/availableNumbers.test.js
+++ b/src/api/phoneNumbers/availableNumbers.test.js
@@ -9,7 +9,7 @@ describe('availableNumbers', function () {
   var authToken = 'mock_auth_token'
   describe('availableNumbers#getList', function () {
     it('should call fetch get with the availablePhoneNumbers endpoint and the query options', function () {
-      var queryOptions = {alias: '(234) 234-2432', phoneNumber: '^\\+1847[0-9]{7}$'}
+      var queryOptions = {alias: '(234) 234-2432', phoneNumber: '^\+1847[0-9]{7}$'}
       var getMock = jest.fn().mockReturnValue(Promise.resolve({ok: true, json: jest.fn().mockReturnValue(Promise.resolve({}))}))
       requester.GET = getMock
 

--- a/src/api/phoneNumbers/incomingNumbers.test.js
+++ b/src/api/phoneNumbers/incomingNumbers.test.js
@@ -101,7 +101,7 @@ describe('incomingNumbers', function () {
       var getMock = jest.fn().mockReturnValue(Promise.resolve({ok: true, json: jest.fn().mockReturnValue(Promise.resolve({}))}))
       requester.GET = getMock
 
-      var filter = {phoneNumber: '^\\+1[0-9]{3}3243$', alias: '(123) 324-5843'}
+      var filter = {phoneNumber: '^\+1[0-9]{3}3243$', alias: '(123) 324-5843'}
 
       expect.assertions(1)
       return incomingNumbers(accountId, authToken).getList(filter).then(function (list) {


### PR DESCRIPTION
For the `/AvailablePhoneNumbers` and `/IncomingPhoneNumbers` endpoints,
only use a single escape for the `+` character.