### PR TITLE
fix jsdoc syntax

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -18,7 +18,7 @@ var requester = require('./requester/index')
  * @type {Object}
  * @property {module:freeclimb-sdk/api/accounts} accounts - The Accounts module
  * @property {module:freeclimb-sdk/api/applications} applications - The Applications module
- * @property {module:freeclimb-sdk/api/availableNumbers} availableNumbers - The Available Numbers module
+ * @property {module:freeclimb-sdk/api/availablePhoneNumbers} availableNumbers - The Available Numbers module
  * @property {module:freeclimb-sdk/api/incomingNumbers} incomingNumbers - the Incoming Numbers module
  * @property {module:freeclimb-sdk/api/callingNumbers} callingNumbers - the Calling Numbers module
  * @property {module:freeclimb-sdk/api/calls} calls - the Calls module

--- a/src/api/calls/calls.js
+++ b/src/api/calls/calls.js
@@ -1,4 +1,8 @@
-var assign = require('lodash.assign')
+/**
+ * @module freeclimb-sdk/api/calls
+ */
+
+ var assign = require('lodash.assign')
 var requester = require('../requester/index')
 var common = require('../common/index')
 


### PR DESCRIPTION
The jsdoc syntax was incorrect for calls and availablePhoneNumbers. This PR fixes that.